### PR TITLE
Using composer require command to install package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,10 @@ Thanks to them and all the contributors!
 
 ### Composer ###
 
-Add this to your composer.json
+Run the following command to install the package
 
-```json
-{
-    "require": {
-        "esi/bench": "~3.0.0"
-    }
-}
+```shell
+composer require esi/bench:~3.0.0
 ```
 
 ## Usage


### PR DESCRIPTION
# Changed log

- Using the `composer require` command to install this package.
- If using the original approach, we need to run `composer install` or `composer update` commands after editing the `composer.json` file.
  - It's not easy and complicated. To simplify the approach, using the `composer require` command instead.